### PR TITLE
fix!: convert newMethodMap and updateServer to static properties

### DIFF
--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -69,7 +69,7 @@ Your plugin can do one or more of 3 basic things:
 
 #### Updating the server
 
-You probably don't normally need to update the Appium server object (which is an Express server having already been configured in a variety of ways). But, for example, you could add new Express middleware to the server to support your plugin's requirements. To update the server you must implement the `async updateServer` method in your class. This method takes two parameters:
+You probably don't normally need to update the Appium server object (which is an Express server having already been configured in a variety of ways). But, for example, you could add new Express middleware to the server to support your plugin's requirements. To update the server you must implement the `static async updateServer` method in your class. This method takes two parameters:
 
 * `expressApp`: the Express app object
 * `httpServer`: the Node HTTP server object
@@ -103,7 +103,7 @@ These parameters define an incoming request. If you want to handle a command in 
 
 ### Adding new routes/commands
 
-You might decide that you want to add some new routes or commands to the Appium server, which could be called by clients. To do this, you should assign the `newMethodMap` class variable to an object containing a set of routes and command names and arguments. The format of this object should exactly match the format of the `METHOD_MAP` object in Appium's [routes definition](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js). Of course, just adding commands here does not implement them: you will also need to check for any new command names in your `handle` method to handle them, since by default there will be no implementation of commands added via `newMethodMap`.
+You might decide that you want to add some new routes or commands to the Appium server, which could be called by clients. To do this, you should assign the static `newMethodMap` class variable to an object containing a set of routes and command names and arguments. The format of this object should exactly match the format of the `METHOD_MAP` object in Appium's [routes definition](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js). Of course, just adding commands here does not implement them: you will also need to check for any new command names in your `handle` method to handle them, since by default there will be no implementation of commands added via `newMethodMap`.
 
 ## Tips
 

--- a/packages/base/lib/plugin.js
+++ b/packages/base/lib/plugin.js
@@ -11,7 +11,7 @@ export default class BasePlugin {
   //      POST: {command: 'setNewThing', payloadParams: {required: ['someParam']}}
   //   }
   // }
-  newMethodMap = {};
+  static newMethodMap = {};
 
   constructor (pluginName) {
     this.name = pluginName;
@@ -28,13 +28,10 @@ export default class BasePlugin {
    * In order to add a new route to Appium with this plugin. Or, you could add new listeners to the
    * httpServer object.
    *
-   * This method does nothing in BasePlugin, and should be overridden, with this.updatesServer set
-   * to true in the constructor, in a final class.
-   *
    * @param {object} expressApp - the Express 'app' object used by Appium for route handling
    * @param {http.Server} httpServer - the node HTTP server that hosts the app
    */
-  /*async updateServer (expressApp, httpServer) {
+  /*static async updateServer (expressApp, httpServer) {
   }*/
 
   /**

--- a/packages/base/test/unit/plugin-specs.js
+++ b/packages/base/test/unit/plugin-specs.js
@@ -18,11 +18,9 @@ describe('base plugin', function () {
     should.exist(p.logger);
   });
   it('should define no server update method', function () {
-    const p = new BasePlugin('foo');
-    should.not.exist(p.updateServer);
+    should.not.exist(BasePlugin.updateServer);
   });
   it('should define a default list of no new methods', function () {
-    const p = new BasePlugin('foo');
-    p.newMethodMap.should.eql({});
+    BasePlugin.newMethodMap.should.eql({});
   });
 });

--- a/packages/fake/lib/plugin.js
+++ b/packages/fake/lib/plugin.js
@@ -6,21 +6,19 @@ import B from 'bluebird';
 
 export default class FakePlugin extends BasePlugin {
 
-  newMethodMap = {
+  static newMethodMap = {
     '/session/:sessionId/fake_data': {
       GET: {command: 'getFakeSessionData'},
       POST: {command: 'setFakeSessionData', payloadParams: {required: ['data']}}
     },
   };
 
-  fakeRoute (req, res) {
-    this.logger.debug('Sending fake route response');
+  static fakeRoute (req, res) {
     res.send(JSON.stringify({fake: 'fakeResponse'}));
   }
 
-  async updateServer (expressApp/*, httpServer*/) { // eslint-disable-line require-await
-    this.logger.debug('Updating server');
-    expressApp.all('/fake', this.fakeRoute.bind(this));
+  static async updateServer (expressApp/*, httpServer*/) { // eslint-disable-line require-await
+    expressApp.all('/fake', FakePlugin.fakeRoute);
   }
 
   async getPageSource (next, driver, ...args) {

--- a/packages/fake/test/unit/plugin-specs.js
+++ b/packages/fake/test/unit/plugin-specs.js
@@ -35,10 +35,9 @@ describe('fake plugin', function () {
   });
 
   it('should update an express app with a fake route', async function () {
-    const p = new FakePlugin('fake');
     const app = new FakeExpress();
     await app.get('/fake').should.eventually.be.rejected;
-    p.updateServer(app);
+    FakePlugin.updateServer(app);
     await app.get('/fake').should.eventually.eql(JSON.stringify({fake: 'fakeResponse'}));
   });
 

--- a/packages/images/lib/plugin.js
+++ b/packages/images/lib/plugin.js
@@ -35,7 +35,7 @@ export default class ImageElementPlugin extends BasePlugin {
   }
 
   // this plugin supports a non-standard 'compare images' command
-  newMethodMap = {
+  static newMethodMap = {
     '/session/:sessionId/appium/compare_images': {
       POST: {
         command: 'compareImages',


### PR DESCRIPTION
This follows the new pattern that will be established in Appium. It makes sense for these to be static properties since they are things the plugin does one time on server start.