### PR TITLE
fix(fake): add export

### DIFF
--- a/packages/fake/lib/plugin.js
+++ b/packages/fake/lib/plugin.js
@@ -67,3 +67,5 @@ export default class FakePlugin extends BasePlugin {
     return null;
   }
 }
+
+export { FakePlugin };


### PR DESCRIPTION
Fake plugin hasn't exported the plugin, so nothing command could find defined as `newMethodMap`