### PR TITLE
feat(config): add schema support

### DIFF
--- a/packages/base/index.d.ts
+++ b/packages/base/index.d.ts
@@ -4,7 +4,6 @@ import type { BaseDriver } from '@appium/base-driver';
 
 export default class BasePlugin {
     static newMethodMap: {};
-    static get argsConstraints(): {};
     constructor(pluginName: string, opts?: {});
     name: string;
     logger: any;

--- a/packages/fake/lib/plugin.js
+++ b/packages/fake/lib/plugin.js
@@ -9,17 +9,6 @@ export default class FakePlugin extends BasePlugin {
     super(pluginName, opts);
   }
 
-  static get argsConstraints () {
-    return {
-      sillyWebServerPort: {
-        isNumber: true
-      },
-      host: {
-        isString: true
-      },
-    };
-  }
-
   async getFakePluginArgs () {
     await B.delay(1);
     return this.cliArgs;

--- a/packages/fake/package.json
+++ b/packages/fake/package.json
@@ -24,6 +24,22 @@
     "scripts": {
       "fake-error": "./build/lib/scripts/fake-error.js",
       "fake-success": "./build/lib/scripts/fake-success.js"
+    },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema",
+      "additionalProperties": false,
+      "description": "Appium configuration schema for the Fake plugin.",
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "silly-web-server-port": {
+          "appiumCliDest": "sillyWebServerPort",
+          "type": "integer"
+        }
+      },
+      "title": "Fake Plugin Configuration",
+      "type": "object"
     }
   },
   "main": "./build/index.js",


### PR DESCRIPTION
This PR adds a schema to `fake-plugin` as per appium/appium#15938, adapted from the `argsConstraints` field.

I have removed `argsConstraints` from the type definition of the base plugin.

Once appium/appium#15938 is released, we can safely remove `argsConstraints` from `BasePlugin`, but I think it'll cause problems if it is removed right now.